### PR TITLE
Fix problems with keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -9,7 +9,7 @@ DynamixelX        	KEYWORD1
 
 # Methods and Functions (KEYWORD2)
 
-SetDirPin         KEYWORD2
+SetDirPin       	KEYWORD2
 begin           	KEYWORD2
 end             	KEYWORD2
 reset           	KEYWORD2
@@ -28,9 +28,9 @@ ledStatus       	KEYWORD2
 setTempLimit    	KEYWORD2
 setAngleLimit   	KEYWORD2
 setVoltageLimit 	KEYWORD2
-setMaxTorque      KEYWORD2
+setMaxTorque    	KEYWORD2
 setSRL          	KEYWORD2
-setRDT            KEYWORD2
+setRDT          	KEYWORD2
 setLEDAlarm      	KEYWORD2
 setShutdownAlarm   	KEYWORD2
 setCMargin         	KEYWORD2
@@ -40,11 +40,11 @@ moving            	KEYWORD2
 lockRegister       	KEYWORD2
 RWStatus        	KEYWORD2
 readSpeed        	KEYWORD2
-readLoad          KEYWORD2
+readLoad        	KEYWORD2
 readPosition    	KEYWORD2
 readTemperature 	KEYWORD2
 readVoltage     	KEYWORD2
-setTorque         KEYWORD2
+setTorque       	KEYWORD2
 
 # Constants (LITERAL1)
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -48,7 +48,7 @@ setTorque       	KEYWORD2
 
 # Constants (LITERAL1)
 
-OFF     	        LITERAL1
+OFF             	LITERAL1
 ON              	LITERAL1
 LEFT            	LITERAL1
 RIGTH           	LITERAL1


### PR DESCRIPTION
- Use correct field separator.
- Remove leading space from keyword identifier token.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords